### PR TITLE
Update web Dockerfile source and compose build

### DIFF
--- a/deploy.env
+++ b/deploy.env
@@ -309,6 +309,8 @@ APPFLOWY_WORKER_DATABASE_NAME=${POSTGRES_DB}
 # AppFlowy Web
 # If your AppFlowy Web is hosted on a different domain, update this variable to the correct domain
 APPFLOWY_WEB_URL=${APPFLOWY_BASE_URL}
+AF_BASIC_AUTH_USER=
+AF_BASIC_AUTH_PWD=
 
 # If you are running AppFlowy Web locally for development purpose, use the following value instead
 # APPFLOWY_WEB_URL=http://localhost:3000

--- a/dev.env
+++ b/dev.env
@@ -202,6 +202,8 @@ APPFLOWY_WORKER_DATABASE_URL=postgres://postgres:password@localhost:5432/postgre
 
 # AppFlowy Web
 APPFLOWY_WEB_URL=http://localhost:3000
+AF_BASIC_AUTH_USER=
+AF_BASIC_AUTH_PWD=
 
 # =============================================================================
 # 🗄️ PGADMIN: Database Management Web Interface

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -212,7 +212,16 @@ services:
 
   appflowy_web:
     restart: on-failure
+    build:
+      context: .
+      dockerfile: ./docker/web/Dockerfile
+      args:
+        AF_BASIC_AUTH_USER: ${AF_BASIC_AUTH_USER}
+        AF_BASIC_AUTH_PWD: ${AF_BASIC_AUTH_PWD}
     image: appflowyinc/appflowy_web:${APPFLOWY_WEB_VERSION:-latest}
+    environment:
+      - AF_BASIC_AUTH_USER=${AF_BASIC_AUTH_USER}
+      - AF_BASIC_AUTH_PWD=${AF_BASIC_AUTH_PWD}
     depends_on:
       - appflowy_cloud
 volumes:

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -4,9 +4,14 @@ FROM node:20.12.0 AS builder
 WORKDIR /app
 
 ARG VERSION=main
+ARG AF_BASIC_AUTH_USER
+ARG AF_BASIC_AUTH_PWD
+
+ENV AF_BASIC_AUTH_USER=${AF_BASIC_AUTH_USER}
+ENV AF_BASIC_AUTH_PWD=${AF_BASIC_AUTH_PWD}
 
 RUN npm install -g pnpm@8.5.0
-RUN git clone --depth 1 --branch ${VERSION} https://github.com/AppFlowy-IO/AppFlowy-Web.git .
+RUN git clone --depth 1 --branch ${VERSION} https://github.com/bos-hieu/AppFlowy-Web.git .
 RUN pnpm install
 RUN sed -i 's|https://test.appflowy.cloud||g' src/components/main/app.hooks.ts
 RUN pnpm run build


### PR DESCRIPTION
## Summary
- build AppFlowy Web from bos-hieu/AppFlowy-Web repo
- expose AF_BASIC_AUTH variables in the web Dockerfile
- build the web image from docker-compose using the Dockerfile
- add AF_BASIC_AUTH_USER and AF_BASIC_AUTH_PWD defaults to env files

## Testing
- `cargo fmt --check` *(fails: 'cargo-fmt' not installed)*
- `cargo test --locked --no-run` *(fails to fetch dependencies due to network)*

------
https://chatgpt.com/codex/tasks/task_e_686e27e5c9bc8325bf6d88b3f6ad0c72