### PR TITLE
Add nginx basic auth

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf
       - ./nginx/ssl/certificate.crt:/etc/nginx/ssl/certificate.crt
       - ./nginx/ssl/private_key.key:/etc/nginx/ssl/private_key.key
+      - ./nginx/.htpasswd:/etc/nginx/.htpasswd:ro
 
   # You do not need this if you have configured to use your own s3 file storage
   minio:

--- a/nginx/.htpasswd
+++ b/nginx/.htpasswd
@@ -1,0 +1,1 @@
+admin:$apr1$CRuCmoO1$MnUIn7zZlmK2j0KFGe0KU0

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -41,6 +41,10 @@ http {
         listen 443 ssl;
         client_max_body_size 10M;
 
+        # HTTP Basic Authentication
+        auth_basic "Restricted";
+        auth_basic_user_file /etc/nginx/.htpasswd;
+
         underscores_in_headers on;
         set $appflowy_cloud_backend "http://appflowy_cloud:8000";
         set $gotrue_backend "http://gotrue:9999";


### PR DESCRIPTION
## Summary
- enable HTTP Basic Auth for nginx
- mount htpasswd credentials file

## Testing
- `cargo fmt --all -- --check` *(fails: rustfmt not installed)*
- `cargo clippy -- -D warnings` *(fails: clippy not installed)*
- `cargo test` *(fails: network error fetching dependencies)*


------
https://chatgpt.com/codex/tasks/task_e_686f15a157748325912f6b6678a5c8e0